### PR TITLE
fix npc armor

### DIFF
--- a/module/actor/sheet/npc-sheet.js
+++ b/module/actor/sheet/npc-sheet.js
@@ -57,7 +57,7 @@ export class DISNpcSheet extends DISActorSheet {
       .filter((item) => {
         return (
           item.type === CONFIG.DIS.itemTypes.armor &&
-          (!item.data.equippable || item.data.equipped)
+          (!item.system.equippable || item.system.equipped)
         );
       })
       .sort(byName);
@@ -66,8 +66,8 @@ export class DISNpcSheet extends DISActorSheet {
         return (
           item.type === CONFIG.DIS.itemTypes.equipment ||
           (item.type === CONFIG.DIS.itemTypes.armor &&
-            item.data.equippable &&
-            !item.data.equipped)
+            item.system.equippable &&
+            !item.system.equipped)
         );
       })
       .sort(byName);


### PR DESCRIPTION
This fixes #41 , where the npc sheet would just stop working as soon as an NPC was added an armor.

I think this is because data was deprecated and then removed in v12.

Not sure if this bug is present somewhere else in the code, but after a quick look, it seems it is not the case.