### PR TITLE
Targeting is not mandatory to roll for attacks

### DIFF
--- a/module/config.js
+++ b/module/config.js
@@ -1,10 +1,7 @@
 // Namespace Configuration Values
 export const DIS = {};
 
-DIS.flagScope = "deathinspace"; // must match system namw
-DIS.flags = {
-  DEFENDER_DR: "defenderDR",
-};
+DIS.flagScope = "deathinspace"; // must match system name
 
 DIS.itemTypes = {
   armor: "armor",

--- a/module/dialog/attack-dialog.js
+++ b/module/dialog/attack-dialog.js
@@ -23,24 +23,16 @@ export default class AttackDialog extends Application {
 
   /** @override */
   async getData() {
-	  let target = Array.from(game.user.targets)[0];
+    let defenderDR = 12; // default
 
-	    //Checks if target is selected, if not throws a message
-	    if(target == null || target == undefined){
-		ui.notifications.error("Please select a target.")
-	}
-	
-	let targetActorId = target.document.actorId;
-	let actor = game.actors.get(targetActorId);
-	let defenderDR = await this.actor.getFlag(
-      CONFIG.DIS.flagScope,
-      CONFIG.DIS.flags.DEFENDER_DR
-    );
-	defenderDR = actor.system.defenseRating;
-    
-    if (!defenderDR) {
-      defenderDR = 12; // default
+    let target = Array.from(game.user.targets)[0];
+    if (target) {
+      //If target is selected, use target defense rating
+      let targetActorId = target.document.actorId;
+      let targetActor = game.actors.get(targetActorId);
+      defenderDR = targetActor.system.defenseRating;
     }
+	
     return {
       defenderDR,
       hasVoidPoints: this.actor.hasVoidPoints,
@@ -69,11 +61,7 @@ export default class AttackDialog extends Application {
       .find("input[name=use-void-point]")
       .is(":checked");
     this.close();
-    await this.actor.setFlag(
-      CONFIG.DIS.flagScope,
-      CONFIG.DIS.flags.DEFENDER_DR,
-      defenderDR
-    );
+
     if (this.itemId) {
       this.actor.rollAttackWithItem(
         this.itemId,

--- a/system.json
+++ b/system.json
@@ -7,7 +7,7 @@
   "templateVersion": 2,
   "compatibility": {
     "minimum": "11.300",
-    "verified": "11.300"
+    "verified": "12.331"
   },
   "authors": [
     {


### PR DESCRIPTION
@mcglincy @MulliganStu 

Made a small change to the attack roll dialog regarding the defender's DR.

The last code change made targeting mandatory to be able to roll for attack with the dialog (otherwise a notice would come up and prevent the roll). While I understand this could be good since the defender's DR will always be accurate, it confuses players and slows the game down slightly during combat.

So I made a slight change that if no target is selected, the default DR of 12 applies. If a target is selected, the target'S DR is used so this should cover both use cases (the tables that use targeting and those who don't).

While doing so, I noticed that the `CONFIG.DIS.flags.DEFENDER_DR` flag was set in the `_onAttack` method that is called after the `getData` method were it is set. Since the modification by @MulliganStu get the target DR correctly, I cleaned the flag.

Also changed `compatibility.verified` to `12.331`.